### PR TITLE
Fix: typo for QuickAdd Button

### DIFF
--- a/PaperBell/40 - Obsidian/脚本/QuickAdd/test.js
+++ b/PaperBell/40 - Obsidian/脚本/QuickAdd/test.js
@@ -1,6 +1,6 @@
 module.exports = async (params) => {
 
-    window.location.href = "obsidian://open?vault=Rainbell&file=40%20-%20Obsidian%2F%E8%84%9A%E6%9C%AC%2FtasksCalendar%2F%E4%BB%BB%E5%8A%A1%E9%9D%A2%E6%9D%BF";
+    window.location.href = "obsidian://open?vault=Paperbell&file=40%20-%20Obsidian%2F%E8%84%9A%E6%9C%AC%2FtasksCalendar%2F%E4%BB%BB%E5%8A%A1%E9%9D%A2%E6%9D%BF";
 
 }
 


### PR DESCRIPTION
Fix the error of QuickAdd Button.

<img width="992" alt="image" src="https://github.com/user-attachments/assets/8d0798e9-4fec-4faf-b66c-a2c647568ea7" />
