### PR TITLE
fix bug when missing the scholar's photo

### DIFF
--- a/PaperBell/Persons/00. 学者列表.md
+++ b/PaperBell/Persons/00. 学者列表.md
@@ -3,6 +3,16 @@ cssClasses: cards cards-align-bottom cards-2-1 table-50
 ---
 
 ```dataviewjs
-dv.table(["照片", "性别", "称谓", "主页", "邮箱", "机构"], dv.pages("#scholar")
-    .map(b => [("![](" + b.photo + ")"), b.file.link, b.title, ("[website 🔗]("+b.website+")"), b.email, b.institute]))
+dv.table(
+    ["照片", "性别", "称谓", "主页", "邮箱", "机构"],
+    dv.pages("#scholar")
+        .map(b => [
+            b.photo ? `![](${b.photo})` : "👤", // 如果没有照片，使用表情符号 😄 📷
+            b.file.link,
+            b.title,
+            `[website 🔗](${b.website})`,
+            b.email,
+            b.institute
+        ])
+);
 ```


### PR DESCRIPTION
this would help to fix the bug of missing the photo when the sholar did not have a photo:
<img width="239" alt="image" src="https://github.com/user-attachments/assets/2ec9748c-d835-40ef-8e0b-e824a79923bb" />

results(use emoji 👤):
<img width="258" alt="image" src="https://github.com/user-attachments/assets/49d3702f-7167-46b9-80c0-f54f6c4a3f30" />


