### PR TITLE
fix：add guide when do not have the corresponding concepts

### DIFF
--- a/PaperBell/40 - Obsidian/模板/术语模板.md
+++ b/PaperBell/40 - Obsidian/模板/术语模板.md
@@ -22,12 +22,16 @@ names.push(dv.current().name)
 // every: 每个要素都在；
 // some: 某个要素在
 
-dv.table(["论文","期刊","年份"],
-dv.pages(`#paper`)
- .where(t => names.some(x => t.concepts.includes(x)))
- .map(b => [b.file.link, b.journal, b.paper_date])
- .sort(b => b.paper_date, 'desc')
-)
+let papers = dv.pages(`#paper`)
+    .where(t => names.some(x => t.concepts.includes(x)))
+    .map(b => [b.file.link, b.journal, b.paper_date])
+    .sort(b => b.paper_date, 'desc')
+
+if (papers.length > 0) {
+    dv.table(["论文","期刊","年份"], papers)
+} else {
+    dv.paragraph("请使用[@citaionkey]添加论文，并在inputs-zotero文件夹中找到论文，点击右上方编辑，添加对应的concepts的tag（可多选）。")
+}
 ```
 
 ## 相关想法


### PR DESCRIPTION
This would help to fix the issue below and add guide of add concepts (This will help users reduce the mental loss of using Paper bell.).
<img width="805" alt="image" src="https://github.com/user-attachments/assets/9553b78d-1cec-4eca-b5fb-a1f286603899" />
new look：

<img width="733" alt="image" src="https://github.com/user-attachments/assets/d3fbcd3c-c792-408d-8f8e-476616682955" />